### PR TITLE
test: clean up

### DIFF
--- a/test/VestingWalletWithCliffAndClawback.t.sol
+++ b/test/VestingWalletWithCliffAndClawback.t.sol
@@ -191,6 +191,8 @@ contract VestingWalletWithCliffAndClawbackTest is Test {
         _assertAbilityToClawback(owner, true);
     }
 
+    // TODO: Test release users too. But this feature must be added first!
+
     // Clawback before cliff should return everything
     function testImmediateClawback() public {
         _assertClawbackHasOccurred(false);

--- a/test/VestingWalletWithCliffAndClawback.t.sol
+++ b/test/VestingWalletWithCliffAndClawback.t.sol
@@ -39,24 +39,15 @@ contract VestingWalletWithCliffAndClawbackTest is Test {
     }
 
     function _clawback(address user) internal {
-        vm.startPrank(user);
-        wallet.clawback();
-        wallet.clawback(address(fakeToken));
-        vm.stopPrank();
+        _assertAbilityToClawback(user, true);
     }
 
     function _release(address user) internal {
-        vm.startPrank(user);
-        wallet.release();
-        wallet.release(address(fakeToken));
-        vm.stopPrank();
+        _assertAbilityToRelease(user, true);
     }
 
     function _sweep(address user) internal {
-        vm.startPrank(user);
-        wallet.sweep();
-        wallet.sweep(address(fakeToken));
-        vm.stopPrank();
+        _assertAbilityToSweep(user, true);
     }
 
     function _assertProceedsEqual(uint256 amount, address user, function (address) func) internal {
@@ -80,7 +71,8 @@ contract VestingWalletWithCliffAndClawbackTest is Test {
         _assertProceedsEqual(amount, owner, _sweep);
     }
 
-    function _assertAbilityTo(string memory funcName, bool expectedSuccess) internal {
+    function _assertAbilityTo(string memory funcName, address user, bool expectedSuccess) internal {
+        vm.startPrank(user);
         bool success;
 
         (success, ) = address(wallet).call(abi.encodeWithSignature(string.concat(funcName, "()")));
@@ -88,16 +80,12 @@ contract VestingWalletWithCliffAndClawbackTest is Test {
 
         (success, ) = address(wallet).call(abi.encodeWithSignature(string.concat(funcName, "(address)"), address(fakeToken)));
         assert(success == expectedSuccess);
-    }
 
-    function _assertAbilityTo(string memory funcName, address user, bool expectedSuccess) internal {
-        vm.startPrank(user);
-        _assertAbilityTo(funcName, expectedSuccess);
         vm.stopPrank();
     }
 
-    function _assertAbilityToRelease(bool expectedSuccess) internal {
-        _assertAbilityTo("release", expectedSuccess);
+    function _assertAbilityToRelease(address user, bool expectedSuccess) internal {
+        _assertAbilityTo("release", user, expectedSuccess);
     }
 
     function _assertAbilityToClawback(address user, bool expectedSuccess) internal {
@@ -173,7 +161,7 @@ contract VestingWalletWithCliffAndClawbackTest is Test {
     function testReleaseAfterCliff() public {
         skip(startDelay + cliffDuration);
         for (uint256 i = startDelay + cliffDuration; i < startDelay + vestDuration; i++) {
-            _assertAbilityToRelease(true);
+            _assertAbilityToRelease(recipient, true);
             skip(1);
         }
     }

--- a/test/VestingWalletWithCliffAndClawback.t.sol
+++ b/test/VestingWalletWithCliffAndClawback.t.sol
@@ -80,37 +80,32 @@ contract VestingWalletWithCliffAndClawbackTest is Test {
         _assertProceedsEqual(amount, owner, _sweep);
     }
 
-    function _assertAbilityToRelease(bool expectedSuccess) internal {
+    function _assertAbilityTo(string memory funcName, bool expectedSuccess) internal {
         bool success;
-        (success, ) = address(wallet).call(abi.encodeWithSignature("release()"));
+
+        (success, ) = address(wallet).call(abi.encodeWithSignature(string.concat(funcName, "()")));
         assert(success == expectedSuccess);
 
-        (success, ) = address(wallet).call(abi.encodeWithSignature("release(address)", address(fakeToken)));
+        (success, ) = address(wallet).call(abi.encodeWithSignature(string.concat(funcName, "(address)"), address(fakeToken)));
         assert(success == expectedSuccess);
+    }
+
+    function _assertAbilityTo(string memory funcName, address user, bool expectedSuccess) internal {
+        vm.startPrank(user);
+        _assertAbilityTo(funcName, expectedSuccess);
+        vm.stopPrank();
+    }
+
+    function _assertAbilityToRelease(bool expectedSuccess) internal {
+        _assertAbilityTo("release", expectedSuccess);
     }
 
     function _assertAbilityToClawback(address user, bool expectedSuccess) internal {
-        bool success;
-
-        vm.prank(user);
-        (success, ) = address(wallet).call(abi.encodeWithSignature("clawback()"));
-        assert(success == expectedSuccess);
-
-        vm.prank(user);
-        (success, ) = address(wallet).call(abi.encodeWithSignature("clawback(address)", address(fakeToken)));
-        assert(success == expectedSuccess);
+        _assertAbilityTo("clawback", user, expectedSuccess);
     }
 
     function _assertAbilityToSweep(address user, bool expectedSuccess) internal {
-        bool success;
-
-        vm.prank(user);
-        (success, ) = address(wallet).call(abi.encodeWithSignature("sweep()"));
-        assert(success == expectedSuccess);
-
-        vm.prank(user);
-        (success, ) = address(wallet).call(abi.encodeWithSignature("sweep(address)", address(fakeToken)));
-        assert(success == expectedSuccess);
+        _assertAbilityTo("sweep", user, expectedSuccess);
     }
 
     function _depositTokensAndEth(address user, uint256 amt) internal {

--- a/test/VestingWalletWithCliffAndClawback.t.sol
+++ b/test/VestingWalletWithCliffAndClawback.t.sol
@@ -241,6 +241,7 @@ contract VestingWalletWithCliffAndClawbackTest is Test {
 
         _clawback(owner);
 
+        // Only owner can sweep after clawback
         _assertAbilityToSweep(provider, false);
         _assertAbilityToSweep(recipient, false);
         _assertAbilityToSweep(owner, true);

--- a/test/VestingWalletWithCliffAndClawback.t.sol
+++ b/test/VestingWalletWithCliffAndClawback.t.sol
@@ -165,7 +165,7 @@ contract VestingWalletWithCliffAndClawbackTest is Test {
     function testReleaseAfterCliff() public {
         skip(startDelay + cliffDuration);
         for (uint256 i = startDelay + cliffDuration; i < startDelay + vestDuration; i++) {
-            _assertAbilityToRelease(recipient, true);
+            _assertProceedsFromReleaseEqual(wallet.releasable());
             skip(1);
         }
     }

--- a/test/VestingWalletWithCliffAndClawback.t.sol
+++ b/test/VestingWalletWithCliffAndClawback.t.sol
@@ -108,14 +108,14 @@ contract VestingWalletWithCliffAndClawbackTest is Test {
         _assertAbilityTo("sweep", user, expectedSuccess);
     }
 
-    function _depositTokensAndEth(address user, uint256 amt) internal {
+    function _depositTokensAndEth(address user, uint256 amount) internal {
         vm.prank(user);
-        (bool success, ) = address(wallet).call{value: amt}("");
+        (bool success, ) = address(wallet).call{value: amount}("");
         assert(success);
-        assert(amt == address(wallet).balance);
+        assert(amount == address(wallet).balance);
         vm.prank(user);
-        fakeToken.transfer(address(wallet), amt);
-        assert(amt == fakeToken.balanceOf(address(wallet)));
+        fakeToken.transfer(address(wallet), amount);
+        assert(amount == fakeToken.balanceOf(address(wallet)));
     }
 
     function setUp() public {

--- a/test/VestingWalletWithCliffAndClawback.t.sol
+++ b/test/VestingWalletWithCliffAndClawback.t.sol
@@ -59,33 +59,25 @@ contract VestingWalletWithCliffAndClawbackTest is Test {
         vm.stopPrank();
     }
 
-    function _assertProceedsFromClawbackEqual(uint256 amount) internal {
-        (uint256 prevBalanceEth, uint256 prevBalanceToken) = _getErc20AndEthBalances(owner);
-        _clawback(owner);
-        (uint256 postBalanceEth, uint256 postBalanceToken) = _getErc20AndEthBalances(owner);
+    function _assertProceedsEqual(uint256 amount, address user, function (address) func) internal {
+        (uint256 prevBalanceEth, uint256 prevBalanceToken) = _getErc20AndEthBalances(user);
+        func(user);
+        (uint256 postBalanceEth, uint256 postBalanceToken) = _getErc20AndEthBalances(user);
 
-        // Owner gets their tokens back
         assert(postBalanceEth - prevBalanceEth == amount);
         assert(postBalanceToken - prevBalanceToken == amount);
+    }
+
+    function _assertProceedsFromClawbackEqual(uint256 amount) internal {
+        _assertProceedsEqual(amount, owner, _clawback);
     }
 
     function _assertProceedsFromReleaseEqual(uint256 amount) internal {
-        (uint256 prevBalanceEth, uint256 prevBalanceToken) = _getErc20AndEthBalances(recipient);
-        _release(recipient);
-        (uint256 postBalanceEth, uint256 postBalanceToken) = _getErc20AndEthBalances(recipient);
-
-        // Owner gets their tokens back
-        assert(postBalanceEth - prevBalanceEth == amount);
-        assert(postBalanceToken - prevBalanceToken == amount);
+        _assertProceedsEqual(amount, recipient, _release);
     }
 
     function _assertProceedsFromSweepEqual(uint256 amount) internal {
-        (uint256 prevBalanceEth, uint256 prevBalanceToken) = _getErc20AndEthBalances(owner);
-        _sweep(owner);
-        (uint256 postBalanceEth, uint256 postBalanceToken) = _getErc20AndEthBalances(owner);
-
-        assert(postBalanceEth - prevBalanceEth == amount);
-        assert(postBalanceToken - prevBalanceToken == amount);
+        _assertProceedsEqual(amount, owner, _sweep);
     }
 
     function _assertAbilityToRelease(bool expectedSuccess) internal {

--- a/test/VestingWalletWithCliffAndClawback.t.sol
+++ b/test/VestingWalletWithCliffAndClawback.t.sol
@@ -146,10 +146,10 @@ contract VestingWalletWithCliffAndClawbackTest is Test {
 
     function testNothingReleasedBeforeCliff() public {
         skip(startDelay);
-        _assertReleasableIsAmount(0);
+        _assertProceedsFromReleaseEqual(0);
 
         skip(cliffDuration - 1);
-        _assertReleasableIsAmount(0);
+        _assertProceedsFromReleaseEqual(0);
     }
 
     function testReleasableAfterCliffNonZero() public {

--- a/test/VestingWalletWithCliffAndClawback.t.sol
+++ b/test/VestingWalletWithCliffAndClawback.t.sol
@@ -110,13 +110,15 @@ contract VestingWalletWithCliffAndClawbackTest is Test {
 
     function setUp() public {
         uint64 startTime = uint64(block.timestamp) + startDelay;        
+
         factory = new VestingWalletWithCliffAndClawbackFactory();
         address walletAddress = factory.create(owner, recipient, startTime, vestDuration, cliffDuration);
         wallet = VestingWalletWithCliffAndClawback(payable(walletAddress));
+
         vm.deal(provider, 1000 ether);
         vm.deal(recipient, 1 ether);
 
-        fakeToken = new ERC20("Fake Token","FAKE");
+        fakeToken = new ERC20("Fake Token", "FAKE");
         deal(address(fakeToken), provider, amountDeposit * 2);
 
         _depositTokensAndEth(provider, amountDeposit);

--- a/test/VestingWalletWithCliffAndClawback.t.sol
+++ b/test/VestingWalletWithCliffAndClawback.t.sol
@@ -38,6 +38,31 @@ contract VestingWalletWithCliffAndClawbackTest is Test {
         return (address(user).balance, fakeToken.balanceOf(user));
     }
 
+    function _assertAbilityTo(string memory funcName, address user, bool expectedSuccess) internal {
+        vm.startPrank(user);
+        bool success;
+
+        (success, ) = address(wallet).call(abi.encodeWithSignature(string.concat(funcName, "()")));
+        assert(success == expectedSuccess);
+
+        (success, ) = address(wallet).call(abi.encodeWithSignature(string.concat(funcName, "(address)"), address(fakeToken)));
+        assert(success == expectedSuccess);
+
+        vm.stopPrank();
+    }
+
+    function _assertAbilityToRelease(address user, bool expectedSuccess) internal {
+        _assertAbilityTo("release", user, expectedSuccess);
+    }
+
+    function _assertAbilityToClawback(address user, bool expectedSuccess) internal {
+        _assertAbilityTo("clawback", user, expectedSuccess);
+    }
+
+    function _assertAbilityToSweep(address user, bool expectedSuccess) internal {
+        _assertAbilityTo("sweep", user, expectedSuccess);
+    }
+
     function _clawback(address user) internal {
         _assertAbilityToClawback(user, true);
     }
@@ -69,31 +94,6 @@ contract VestingWalletWithCliffAndClawbackTest is Test {
 
     function _assertProceedsFromSweepEqual(uint256 amount) internal {
         _assertProceedsEqual(amount, owner, _sweep);
-    }
-
-    function _assertAbilityTo(string memory funcName, address user, bool expectedSuccess) internal {
-        vm.startPrank(user);
-        bool success;
-
-        (success, ) = address(wallet).call(abi.encodeWithSignature(string.concat(funcName, "()")));
-        assert(success == expectedSuccess);
-
-        (success, ) = address(wallet).call(abi.encodeWithSignature(string.concat(funcName, "(address)"), address(fakeToken)));
-        assert(success == expectedSuccess);
-
-        vm.stopPrank();
-    }
-
-    function _assertAbilityToRelease(address user, bool expectedSuccess) internal {
-        _assertAbilityTo("release", user, expectedSuccess);
-    }
-
-    function _assertAbilityToClawback(address user, bool expectedSuccess) internal {
-        _assertAbilityTo("clawback", user, expectedSuccess);
-    }
-
-    function _assertAbilityToSweep(address user, bool expectedSuccess) internal {
-        _assertAbilityTo("sweep", user, expectedSuccess);
     }
 
     function _depositTokensAndEth(address user, uint256 amount) internal {

--- a/test/VestingWalletWithCliffAndClawback.t.sol
+++ b/test/VestingWalletWithCliffAndClawback.t.sol
@@ -79,7 +79,6 @@ contract VestingWalletWithCliffAndClawbackTest is Test {
         assert(postBalanceToken - prevBalanceToken == amount);
     }
 
-
     function _assertProceedsFromSweepEqual(uint256 amount) internal {
         (uint256 prevBalanceEth, uint256 prevBalanceToken) = _getErc20AndEthBalances(owner);
         _sweep(owner);
@@ -173,7 +172,6 @@ contract VestingWalletWithCliffAndClawbackTest is Test {
         skip(cliffDuration - 1);
         _assertReleasableIsAmount(0);
     }
-
 
     function testReleasableAfterCliffNonZero() public {
         skip(startDelay + cliffDuration);

--- a/test/VestingWalletWithCliffAndClawback.t.sol
+++ b/test/VestingWalletWithCliffAndClawback.t.sol
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import "forge-std/Test.sol";
 import "forge-std/StdCheats.sol";
+import "forge-std/Test.sol";
+
+import "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+
 import "../src/VestingWalletWithCliffAndClawback.sol";
 import "../src/VestingWalletWithCliffAndClawbackFactory.sol";
-import "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 
 contract VestingWalletWithCliffAndClawbackTest is Test {
     VestingWalletWithCliffAndClawbackFactory public factory;

--- a/test/VestingWalletWithCliffAndClawback.t.sol
+++ b/test/VestingWalletWithCliffAndClawback.t.sol
@@ -111,7 +111,7 @@ contract VestingWalletWithCliffAndClawbackTest is Test {
         _assertReleasableIsAmount(0);
     }
 
-    function _assertProceedsFromReleaseMatchReleasable() internal {
+    function _assertProceedsFromReleaseEqualReleasable() internal {
         uint256 amount = _getReleasableAmount();
         _assertProceedsEqual(amount, recipient, _release);
         _assertReleasableIsAmount(0);
@@ -176,7 +176,7 @@ contract VestingWalletWithCliffAndClawbackTest is Test {
     function testReleaseAfterCliff() public {
         skip(startDelay + cliffDuration);
         for (uint256 i = startDelay + cliffDuration; i < startDelay + vestDuration; i++) {
-            _assertProceedsFromReleaseMatchReleasable();
+            _assertProceedsFromReleaseEqualReleasable();
             skip(1);
         }
     }

--- a/test/VestingWalletWithCliffAndClawback.t.sol
+++ b/test/VestingWalletWithCliffAndClawback.t.sol
@@ -11,17 +11,6 @@ contract VestingWalletWithCliffAndClawbackTest is Test {
     VestingWalletWithCliffAndClawbackFactory public factory;
     VestingWalletWithCliffAndClawback public wallet;
 
-    // Foundry does not handle overloaded functions well at all.
-    // Manually entering the function selectors here is the easiest workaround.
-    bytes4 constant releaseSelector = "\x86\xd1\xa6\x9f";
-    bytes4 constant releaseAddressSelector = "\x19\x16\x55\x87";
-    bytes4 constant clawbackSelector = "\x25\x26\xd9\x60";
-    bytes4 constant clawbackAddressSelector = "\xed\xf6\x85\x58";
-    bytes4 constant sweepSelector = "\x35\xfa\xa4\x16";
-    bytes4 constant sweepAddressSelector = "\x01\x68\x1a\x62";
-    bytes4 constant clawbackHasOccurredSelector = "\x37\x29\xc2\x21";
-    bytes4 constant clawbackHasOccurredAddressSelector = "\x0e\x9f\x2b\xea";
-
     address provider = vm.addr(0x1);
     address recipient = vm.addr(0x2);
     address owner = vm.addr(0x3);
@@ -100,10 +89,10 @@ contract VestingWalletWithCliffAndClawbackTest is Test {
 
     function _assertAbilityToRelease(bool expectedSuccess) internal {
         bool success;
-        (success, ) = address(wallet).call(abi.encodeWithSelector(releaseSelector));
+        (success, ) = address(wallet).call(abi.encodeWithSignature("release()"));
         assert(success == expectedSuccess);
 
-        (success, ) = address(wallet).call(abi.encodeWithSelector(releaseAddressSelector, address(fakeToken)));
+        (success, ) = address(wallet).call(abi.encodeWithSignature("release(address)", address(fakeToken)));
         assert(success == expectedSuccess);
     }
 
@@ -111,11 +100,11 @@ contract VestingWalletWithCliffAndClawbackTest is Test {
         bool success;
 
         vm.prank(user);
-        (success, ) = address(wallet).call(abi.encodeWithSelector(clawbackSelector));
+        (success, ) = address(wallet).call(abi.encodeWithSignature("clawback()"));
         assert(success == expectedSuccess);
 
         vm.prank(user);
-        (success, ) = address(wallet).call(abi.encodeWithSelector(clawbackAddressSelector, address(fakeToken)));
+        (success, ) = address(wallet).call(abi.encodeWithSignature("clawback(address)", address(fakeToken)));
         assert(success == expectedSuccess);
     }
 
@@ -123,11 +112,11 @@ contract VestingWalletWithCliffAndClawbackTest is Test {
         bool success;
 
         vm.prank(user);
-        (success, ) = address(wallet).call(abi.encodeWithSelector(sweepSelector));
+        (success, ) = address(wallet).call(abi.encodeWithSignature("sweep()"));
         assert(success == expectedSuccess);
 
         vm.prank(user);
-        (success, ) = address(wallet).call(abi.encodeWithSelector(sweepAddressSelector, address(fakeToken)));
+        (success, ) = address(wallet).call(abi.encodeWithSignature("sweep(address)", address(fakeToken)));
         assert(success == expectedSuccess);
     }
 

--- a/test/VestingWalletWithCliffAndClawback.t.sol
+++ b/test/VestingWalletWithCliffAndClawback.t.sol
@@ -101,8 +101,10 @@ contract VestingWalletWithCliffAndClawbackTest is Test {
         (bool success, ) = address(wallet).call{value: amount}("");
         assert(success);
         assert(amount == address(wallet).balance);
+
         vm.prank(user);
-        fakeToken.transfer(address(wallet), amount);
+        success = fakeToken.transfer(address(wallet), amount);
+        assert(success);
         assert(amount == fakeToken.balanceOf(address(wallet)));
     }
 


### PR DESCRIPTION
Remove hard-coded selectors, unify style, de-duplicate lots of code.

Also fixes some erroneous interchangeability of `releasable` and `release`. Always tests both together (except when testing specific `releasable` amounts in loops, where `release` would update storage and ruin the next iteration).

After https://github.com/gerrrg/VestingWalletWithCliffAndClawback/pull/5 is merged, I will change the base branch for this PR to `main`.

In the process of authoring this PR, I also discovered a missing feature: https://github.com/gerrrg/VestingWalletWithCliffAndClawback/issues/10. That should be the next most critical fix.