### PR TITLE
feat: prevent public from calling `release`

### DIFF
--- a/src/VestingWalletWithCliff.sol
+++ b/src/VestingWalletWithCliff.sol
@@ -8,7 +8,7 @@ import "openzeppelin-contracts/contracts/finance/VestingWallet.sol";
  * @dev This contract builds on OpenZeppelin's VestingWallet. See comments in VestingWallet for base details.
  *
  * This contract adds the following functionality:
- *   - Add a vesting cliff: `recipient` cannot claim any vested tokens until a cliff duration has elapsed
+ *   - Add a vesting cliff: `beneficiary` cannot claim any vested tokens until a cliff duration has elapsed
  */
 abstract contract VestingWalletWithCliff is VestingWallet {
 

--- a/src/VestingWalletWithCliffAndClawback.sol
+++ b/src/VestingWalletWithCliffAndClawback.sol
@@ -1,20 +1,26 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import "./VestingWalletWithCliff.sol";
 import "./VestingWalletWithClawback.sol";
+import "./VestingWalletWithCliff.sol";
+import "./VestingWalletWithReleaseGuard.sol";
 
 /**
  * @title VestingWalletWithCliffAndClawback
  * @dev This contract builds on OpenZeppelin's VestingWallet. See comments in VestingWallet for base details.
  *
  * This contract adds the following functionality:
- *   - Add a vesting cliff: `recipient` cannot claim any vested tokens until a cliff duration has elapsed
  *   - Add `owner`: contract is `Ownable2Step`
  *   - Add clawbacks: contract `owner` can clawback any unvested tokens
  *   - Add post-clawback sweeps: contract `owner` can sweep any excess tokens sent to the contract after clawback
+ *   - Add a vesting cliff: `beneficiary` cannot claim any vested tokens until a cliff duration has elapsed
+ *   - Add a release guard: only `beneficiary` can release vested funds; no one can force funds upon `beneficiary`
  */
-contract VestingWalletWithCliffAndClawback is VestingWalletWithCliff, VestingWalletWithClawback {
+contract VestingWalletWithCliffAndClawback is
+    VestingWalletWithClawback,
+    VestingWalletWithCliff,
+    VestingWalletWithReleaseGuard
+{
 
     /**
      * @dev Set the cliff and owner.
@@ -47,6 +53,16 @@ contract VestingWalletWithCliffAndClawback is VestingWalletWithCliff, VestingWal
         returns (uint256)
     {
         return super.releasable(token);
+    }
+
+    /// @inheritdoc VestingWalletWithReleaseGuard
+    function release() public override(VestingWallet, VestingWalletWithReleaseGuard) {
+        return super.release();
+    }
+
+    /// @inheritdoc VestingWalletWithReleaseGuard
+    function release(address token) public override(VestingWallet, VestingWalletWithReleaseGuard) {
+        return super.release(token);
     }
 
     /// @inheritdoc VestingWalletWithCliff

--- a/src/VestingWalletWithReleaseGuard.sol
+++ b/src/VestingWalletWithReleaseGuard.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "openzeppelin-contracts/contracts/finance/VestingWallet.sol";
+
+/**
+ * @title VestingWalletWithReleaseGuard
+ * @dev This contract builds on OpenZeppelin's VestingWallet. See comments in VestingWallet for base details.
+ *
+ * This contract adds the following functionality:
+ *   - Add a release guard: only `beneficiary` can release vested funds; no one can force funds upon `beneficiary`
+ */
+abstract contract VestingWalletWithReleaseGuard is VestingWallet {
+
+    error CallerIsNotBeneficiary();
+
+    /**
+     * @dev Throws if called by any account other than the beneficiary.
+     */
+    modifier onlyBeneficiary() {
+        if (beneficiary() != msg.sender) {
+            revert CallerIsNotBeneficiary();
+        }
+        _;
+    }
+
+    /**
+     * @dev Override of VestingWallet's `release` to enforce that the caller must be the beneficiary.
+     */
+    function release() public virtual override onlyBeneficiary {
+        super.release();
+    }
+
+    /**
+     * @dev Override of VestingWallet's `release` to enforce that the caller must be the beneficiary.
+     */
+    function release(address token) public virtual override onlyBeneficiary {
+        super.release(token);
+    }
+}


### PR DESCRIPTION
Closes #10

I've intentionally not fixed the test or changed the name of the contract in this PR.
- I did verify locally that the test works with a small change, but #11 will far supersede any changes here so I'd rather avoid it for now.
- I opted not to change the name because it would require touching the test, script, and factory as well, and I'd rather keep this PR clean. We should refactor in another PR after this and #11 get merged. I would suggest changing the name to something more generic like `ExtendedVestingWallet` or `EnhancedVestingWallet` so that it doesn't get too unwieldy.

Like the other PRs, I will change the base to `main` after #5 gets merged.